### PR TITLE
Support recent version of Packer (v0.5.1)

### DIFF
--- a/VyattaCore-6.4-amd64/template.json
+++ b/VyattaCore-6.4-amd64/template.json
@@ -43,7 +43,7 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -103,7 +103,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
       "tools_upload_flavor": "linux",
-      "type": "vmware",
+      "type": "vmware-iso",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "256",
@@ -120,7 +120,7 @@
   "provisioners": [
     {
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",
@@ -129,7 +129,7 @@
             "zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",

--- a/VyattaCore-6.4-amd64/template_chef.json
+++ b/VyattaCore-6.4-amd64/template_chef.json
@@ -43,7 +43,7 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -103,7 +103,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
       "tools_upload_flavor": "linux",
-      "type": "vmware",
+      "type": "vmware-iso",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "256",
@@ -120,7 +120,7 @@
   "provisioners": [
     {
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",
@@ -131,7 +131,7 @@
             "zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",

--- a/VyattaCore-6.5R1-amd64/template.json
+++ b/VyattaCore-6.5R1-amd64/template.json
@@ -43,7 +43,7 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -103,7 +103,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
       "tools_upload_flavor": "linux",
-      "type": "vmware",
+      "type": "vmware-iso",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "256",
@@ -120,7 +120,7 @@
   "provisioners": [
     {
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",
@@ -129,7 +129,7 @@
             "zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",

--- a/VyattaCore-6.5R1-amd64/template_chef.json
+++ b/VyattaCore-6.5R1-amd64/template_chef.json
@@ -43,7 +43,7 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -103,7 +103,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
       "tools_upload_flavor": "linux",
-      "type": "vmware",
+      "type": "vmware-iso",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "256",
@@ -120,7 +120,7 @@
   "provisioners": [
     {
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",
@@ -131,7 +131,7 @@
             "zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",

--- a/VyattaCore-6.6R1-amd64/template.json
+++ b/VyattaCore-6.6R1-amd64/template.json
@@ -43,7 +43,7 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -103,7 +103,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
       "tools_upload_flavor": "linux",
-      "type": "vmware",
+      "type": "vmware-iso",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "256",
@@ -120,7 +120,7 @@
   "provisioners": [
     {
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",
@@ -129,7 +129,7 @@
             "zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",

--- a/VyattaCore-6.6R1-amd64/template_chef.json
+++ b/VyattaCore-6.6R1-amd64/template_chef.json
@@ -43,7 +43,7 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -103,7 +103,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "3000s",
       "tools_upload_flavor": "linux",
-      "type": "vmware",
+      "type": "vmware-iso",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "256",
@@ -120,7 +120,7 @@
   "provisioners": [
     {
       "override": {
-        "virtualbox": {
+        "virtualbox-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",
@@ -131,7 +131,7 @@
             "zerodisk.sh"
           ]
         },
-        "vmware": {
+        "vmware-iso": {
           "scripts": [
             "base.sh",
             "vagrant.sh",


### PR DESCRIPTION
A little bit of change to support recent version of Packer.
Please review and consider merge.

Fixed for Packer v0.5.1. It works for VirtualBox 4.3.6. As for VMware, it is not tested yet.
